### PR TITLE
noncall dtor 1

### DIFF
--- a/include/coffin/goroutine.hpp
+++ b/include/coffin/goroutine.hpp
@@ -200,10 +200,10 @@ public:
       if (ch.closed) {
         assert(false);
       } else if (auto opt = dequeueSudog(ch.recv_queue)) {
-        auto sdg = *opt;
+        auto &sdg = *opt;
         *sdg.val = std::move(val);
         sdg.task->wakeup_id = sdg.wakeup_id;
-        ch.scheduler.push_goroutine(sdg.task);
+        ch.scheduler.push_goroutine(std::move(sdg.task));
         return true;
       } else if (ch.value_queue.size() < ch.queue_limit) {
         ch.value_queue.push_back(std::move(val));
@@ -245,20 +245,20 @@ public:
         val = ch.value_queue.front();
         ch.value_queue.pop_front();
         if (auto opt = dequeueSudog(ch.send_queue)) {
-          auto sdg = *opt;
+          auto &sdg = *opt;
           ch.value_queue.push_back(*sdg.val);
           sdg.task->wakeup_id = sdg.wakeup_id;
-          ch.scheduler.push_goroutine(sdg.task);
+          ch.scheduler.push_goroutine(std::move(sdg.task));
         }
         return true;
       } else if (ch.closed) {
         val = std::nullopt;
         return true;
       } else if (auto opt = dequeueSudog(ch.send_queue)) {
-        auto sdg = *opt;
+        auto &sdg = *opt;
         val = std::move(*sdg.val);
         sdg.task->wakeup_id = sdg.wakeup_id;
-        ch.scheduler.push_goroutine(sdg.task);
+        ch.scheduler.push_goroutine(std::move(sdg.task));
         return true;
       }
       return false;
@@ -282,10 +282,10 @@ public:
       assert(false);
     }
     while (auto opt = dequeueSudog(recv_queue)) {
-      auto sdg = *opt;
+      auto &sdg = *opt;
       *sdg.val = std::nullopt;
       sdg.task->wakeup_id = sdg.wakeup_id;
-      scheduler.push_goroutine(sdg.task);
+      scheduler.push_goroutine(std::move(sdg.task));
     }
   }
   Scheduler scheduler;

--- a/test/test.cpp
+++ b/test/test.cpp
@@ -94,9 +94,9 @@ struct MyScheduler{
         auto g = std::make_shared<cfn::Goroutine>(std::move(task));
         queue.push_back(g);
     }
-    void push_goroutine(std::shared_ptr<cfn::Goroutine> g){
+    void push_goroutine(std::shared_ptr<cfn::Goroutine> && g){
         std::scoped_lock lock{mutex};
-        queue.push_back(g);
+        queue.push_back(std::move(g));
     }
     std::shared_ptr<cfn::Goroutine> dequeue_task(){
         std::scoped_lock lock{mutex};
@@ -319,8 +319,8 @@ struct BoostThreadpoolScheduler {
 static BoostThreadpoolScheduler gbts;
 struct BoostThreadpoolSchedulerWrapper{
     BoostThreadpoolScheduler & ref_;
-    void push_goroutine(std::shared_ptr<cfn::Goroutine> g){
-        ref_.io_service_.post([=](){g->execute(); });
+    void push_goroutine(std::shared_ptr<cfn::Goroutine> && g){
+        ref_.io_service_.post([g=std::move(g)](){g->execute(); });
     }
 };
 


### PR DESCRIPTION

https://github.com/Fuyutsubaki/coffin-goroutine/issues/6
push_goroutineの呼び出しの後もtaskの所有権を持っているとデストラクタ呼び出しが走る可能性がある

このとき taskが Senderなど 「デストラクタで channelのlockを獲得する処理などを呼び出すオブジェクト」を保持しているとdeadlockに陥る

デストラクタが走らないよう、push_goroutineより後で所有権を持たないように修正する




メモ：
- 人類には難しいので型や構造で何とかするべき
- lockを獲得しなくてもユーザ定義の処理が走りうるのはあまりよくない。ちょっと考えるべき